### PR TITLE
chore:(decimal): add decimal type and check #1

### DIFF
--- a/src/config/constants/farms.ts
+++ b/src/config/constants/farms.ts
@@ -7,6 +7,7 @@ const farms: FarmConfig[] = [
     risk: 5,
     isTokenOnly: false,
     lpSymbol: 'GAJ - USDC',
+    decimal: 18,
     lpAddresses: {
       97: '',
       56: '0x19e7cbecdd23a16dfa5573df54d98f7caae03019',
@@ -26,6 +27,7 @@ const farms: FarmConfig[] = [
     risk: 5,
     isTokenOnly: false,
     lpSymbol: 'GAJ - USDT',
+    decimal: 18,
     lpAddresses: {
       97: '',
       56: '0x19e7cbecdd23a16dfa5573df54d98f7caae03019',
@@ -44,6 +46,7 @@ const farms: FarmConfig[] = [
     pid: 1,
     risk: 3,
     lpSymbol: 'WMATIC - USDC',
+    decimal: 18,
     lpAddresses: {
       97: '',
       56: '0x6e7a5fafcec6bb1e78bae2a1f0b612012bf14827',
@@ -63,6 +66,7 @@ const farms: FarmConfig[] = [
     risk: 5,
     isTokenOnly: true,
     lpSymbol: 'GAJ',
+    decimal: 18,
     lpAddresses: {
       97: '',
       56: '0x19e7cbecdd23a16dfa5573df54d98f7caae03019',
@@ -83,6 +87,7 @@ const farms: FarmConfig[] = [
     isTokenOnly: true,
     risk: 3,
     lpSymbol: 'WMATIC',
+    decimal: 18,
     lpAddresses: {
       97: '',
       56: '0x6e7a5fafcec6bb1e78bae2a1f0b612012bf14827',
@@ -102,6 +107,7 @@ const farms: FarmConfig[] = [
     isTokenOnly: true,
     risk: 3,
     lpSymbol: 'MUST',
+    decimal: 18,
     lpAddresses: {
       97: '',
       56: '0x6e7a5fafcec6bb1e78bae2a1f0b612012bf14827',
@@ -121,6 +127,7 @@ const farms: FarmConfig[] = [
     isTokenOnly: true,
     risk: 3,
     lpSymbol: 'WBTC',
+    decimal: 6,
     lpAddresses: {
       97: '',
       56: '0x6e7a5fafcec6bb1e78bae2a1f0b612012bf14827',
@@ -140,6 +147,7 @@ const farms: FarmConfig[] = [
     isTokenOnly: true,
     risk: 3,
     lpSymbol: 'WETH',
+    decimal: 18,
     lpAddresses: {
       97: '',
       56: '0x6e7a5fafcec6bb1e78bae2a1f0b612012bf14827',
@@ -159,6 +167,7 @@ const farms: FarmConfig[] = [
     risk: 5,
     isTokenOnly: true,
     lpSymbol: 'KRILL',
+    decimal: 18,
     lpAddresses: {
       97: '',
       56: '0x19e7cbecdd23a16dfa5573df54d98f7caae03019',
@@ -178,6 +187,7 @@ const farms: FarmConfig[] = [
     isTokenOnly: true,
     risk: 3,
     lpSymbol: 'USDC',
+    decimal: 6,
     lpAddresses: {
       97: '',
       56: '0x6e7a5fafcec6bb1e78bae2a1f0b612012bf14827',
@@ -197,6 +207,7 @@ const farms: FarmConfig[] = [
     isTokenOnly: true,
     risk: 3,
     lpSymbol: 'USDT',
+    decimal: 6,
     lpAddresses: {
       97: '',
       56: '0x6e7a5fafcec6bb1e78bae2a1f0b612012bf14827',

--- a/src/config/constants/types.ts
+++ b/src/config/constants/types.ts
@@ -53,6 +53,7 @@ export interface FarmConfig {
   isTokenOnly?: boolean
   isCommunity?: boolean
   risk: number
+  decimal: number
   dual?: {
     rewardPerBlock: number
     earnLabel: string

--- a/src/hooks/useStake.ts
+++ b/src/hooks/useStake.ts
@@ -5,18 +5,18 @@ import { fetchFarmUserDataAsync, updateUserStakedBalance, updateUserBalance } fr
 import { stake, sousStake, sousStakeBnb } from 'utils/callHelpers'
 import { useMasterchef, useSousChef } from './useContract'
 
-const useStake = (pid: number) => {
+const useStake = (pid: number, decimal: number) => {
   const dispatch = useDispatch()
   const { account } = useWallet()
   const masterChefContract = useMasterchef()
 
   const handleStake = useCallback(
     async (amount: string) => {
-      const txHash = await stake(masterChefContract, pid, amount, account)
+      const txHash = await stake(masterChefContract, pid, amount, account, decimal)
       dispatch(fetchFarmUserDataAsync(account))
       console.info(txHash)
     },
-    [account, dispatch, masterChefContract, pid],
+    [account, dispatch, masterChefContract, pid, decimal],
   )
 
   return { onStake: handleStake }
@@ -29,9 +29,9 @@ export const useSousStake = (sousId, isUsingBnb = false) => {
   const sousChefContract = useSousChef(sousId)
 
   const handleStake = useCallback(
-    async (amount: string) => {
+    async (amount: string, decimal: number) => {
       if (sousId === 0) {
-        await stake(masterChefContract, 0, amount, account)
+        await stake(masterChefContract, 0, amount, account, decimal)
       } else if (isUsingBnb) {
         await sousStakeBnb(sousChefContract, amount, account)
       } else {

--- a/src/hooks/useUnstake.ts
+++ b/src/hooks/useUnstake.ts
@@ -10,18 +10,18 @@ import {
 import { unstake, sousUnstake, sousEmegencyUnstake } from 'utils/callHelpers'
 import { useMasterchef, useSousChef } from './useContract'
 
-const useUnstake = (pid: number) => {
+const useUnstake = (pid: number, decimal: number) => {
   const dispatch = useDispatch()
   const { account } = useWallet()
   const masterChefContract = useMasterchef()
 
   const handleUnstake = useCallback(
     async (amount: string) => {
-      const txHash = await unstake(masterChefContract, pid, amount, account)
+      const txHash = await unstake(masterChefContract, pid, amount, account, decimal)
       dispatch(fetchFarmUserDataAsync(account))
       console.info(txHash)
     },
-    [account, dispatch, masterChefContract, pid],
+    [account, dispatch, masterChefContract, pid, decimal],
   )
 
   return { onUnstake: handleUnstake }
@@ -37,9 +37,9 @@ export const useSousUnstake = (sousId) => {
   const isOldSyrup = SYRUPIDS.includes(sousId)
 
   const handleUnstake = useCallback(
-    async (amount: string) => {
+    async (amount: string, decimal: number) => {
       if (sousId === 0) {
-        const txHash = await unstake(masterChefContract, 0, amount, account)
+        const txHash = await unstake(masterChefContract, 0, amount, account, decimal)
         console.info(txHash)
       } else if (isOldSyrup) {
         const txHash = await sousEmegencyUnstake(sousChefContract, amount, account)

--- a/src/state/farms/fetchFarms.ts
+++ b/src/state/farms/fetchFarms.ts
@@ -67,6 +67,9 @@ const fetchFarms = async () => {
       //   tokenDecimals,farmConfig
       // )
         tokenAmount = new BigNumber(lpTokenBalanceMC).div(new BigNumber(10).pow(6));
+        if(farmConfig.decimal === 6){
+          tokenAmount = new BigNumber(lpTokenBalanceMC).div(new BigNumber(10).pow(farmConfig.decimal))
+        }
         if(farmConfig.tokenSymbol === QuoteToken.BUSD && farmConfig.quoteTokenSymbol === QuoteToken.BUSD){
           tokenPriceVsQuote = new BigNumber(1);
         }else{

--- a/src/utils/callHelpers.ts
+++ b/src/utils/callHelpers.ts
@@ -7,9 +7,9 @@ export const approve = async (lpContract, masterChefContract, account) => {
     .send({ from: account })
 }
 
-export const stake = async (masterChefContract, pid, amount, account) => {
+export const stake = async (masterChefContract, pid, amount, account, decimal) => {
   return masterChefContract.methods
-    .deposit(pid, new BigNumber(amount).times(new BigNumber(10).pow(18)).toString())
+    .deposit(pid, new BigNumber(amount).times(new BigNumber(10).pow(decimal)).toString())
     .send({ from: account })
     .on('transactionHash', (tx) => {
       return tx.transactionHash
@@ -34,9 +34,9 @@ export const sousStakeBnb = async (sousChefContract, amount, account) => {
     })
 }
 
-export const unstake = async (masterChefContract, pid, amount, account) => {
+export const unstake = async (masterChefContract, pid, amount, account, decimal) => {
   return masterChefContract.methods
-    .withdraw(pid, new BigNumber(amount).times(new BigNumber(10).pow(18)).toString())
+    .withdraw(pid, new BigNumber(amount).times(new BigNumber(10).pow(decimal)).toString())
     .send({ from: account })
     .on('transactionHash', (tx) => {
       return tx.transactionHash

--- a/src/views/Farms/components/DepositModal.tsx
+++ b/src/views/Farms/components/DepositModal.tsx
@@ -8,13 +8,14 @@ import { getFullDisplayBalance } from 'utils/formatBalance'
 
 interface DepositModalProps {
   max: BigNumber
-  onConfirm: (amount: string) => void
+  onConfirm: (amount: string, decimal: number) => void
   onDismiss?: () => void
   tokenName?: string
   depositFeeBP?: number
+  decimal?: number
 }
 
-const DepositModal: React.FC<DepositModalProps> = ({ max, onConfirm, onDismiss, tokenName = '' , depositFeeBP = 0}) => {
+const DepositModal: React.FC<DepositModalProps> = ({ max, onConfirm, onDismiss, tokenName = '' , depositFeeBP = 0, decimal = 18}) => {
   const [val, setVal] = useState('')
   const [pendingTx, setPendingTx] = useState(false)
   const TranslateString = useI18n()
@@ -51,7 +52,7 @@ const DepositModal: React.FC<DepositModalProps> = ({ max, onConfirm, onDismiss, 
           disabled={pendingTx}
           onClick={async () => {
             setPendingTx(true)
-            await onConfirm(val)
+            await onConfirm(val, decimal)
             setPendingTx(false)
             onDismiss()
           }}

--- a/src/views/Farms/components/FarmCard/CardActionsContainer.tsx
+++ b/src/views/Farms/components/FarmCard/CardActionsContainer.tsx
@@ -28,7 +28,7 @@ interface FarmCardActionsProps {
 const CardActions: React.FC<FarmCardActionsProps> = ({ farm, ethereum, account }) => {
   const TranslateString = useI18n()
   const [requestedApproval, setRequestedApproval] = useState(false)
-  const { pid, lpAddresses, tokenAddresses, isTokenOnly, depositFeeBP } = useFarmFromPid(farm.pid)
+  const { pid, lpAddresses, tokenAddresses, isTokenOnly, depositFeeBP, decimal } = useFarmFromPid(farm.pid)
   const { allowance, tokenBalance, stakedBalance, earnings } = useFarmUser(pid)
   const lpAddress = lpAddresses[process.env.REACT_APP_CHAIN_ID]
   const tokenAddress = tokenAddresses[process.env.REACT_APP_CHAIN_ID];
@@ -56,7 +56,7 @@ const CardActions: React.FC<FarmCardActionsProps> = ({ farm, ethereum, account }
 
   const renderApprovalOrStakeButton = () => {
     return isApproved ? (
-      <StakeAction stakedBalance={stakedBalance} tokenBalance={tokenBalance} tokenName={lpName} pid={pid} depositFeeBP={depositFeeBP} />
+      <StakeAction stakedBalance={stakedBalance} tokenBalance={tokenBalance} tokenName={lpName} pid={pid} depositFeeBP={depositFeeBP} decimal={decimal} />
     ) : (
       <Button mt="8px" fullWidth disabled={requestedApproval} onClick={handleApprove}>
         {TranslateString(999, 'Approve Contract')}
@@ -74,7 +74,7 @@ const CardActions: React.FC<FarmCardActionsProps> = ({ farm, ethereum, account }
           {TranslateString(999, 'Earned')}
         </Text>
       </Flex>
-      <HarvestAction earnings={earnings} pid={pid} />
+      <HarvestAction earnings={earnings} pid={pid} decimal={decimal} />
       <Flex>
         <Text bold textTransform="uppercase" color="secondary" fontSize="12px" pr="3px">
           {lpName}

--- a/src/views/Farms/components/FarmCard/HarvestAction.tsx
+++ b/src/views/Farms/components/FarmCard/HarvestAction.tsx
@@ -10,6 +10,7 @@ import useStake from '../../../../hooks/useStake'
 interface FarmCardActionsProps {
   earnings?: BigNumber
   pid?: number
+  decimal?: number
 }
 
 const BalanceAndCompound = styled.div`
@@ -19,13 +20,13 @@ const BalanceAndCompound = styled.div`
   flex-direction: column;
 `
 
-const HarvestAction: React.FC<FarmCardActionsProps> = ({ earnings, pid }) => {
+const HarvestAction: React.FC<FarmCardActionsProps> = ({ earnings, pid, decimal }) => {
   const TranslateString = useI18n()
   const [pendingTx, setPendingTx] = useState(false)
   const { onReward } = useHarvest(pid)
-  const { onStake } = useStake(pid)
+  const { onStake } = useStake(pid, decimal)
 
-  const rawEarningsBalance = getBalanceNumber(earnings)
+  const rawEarningsBalance = getBalanceNumber(earnings, decimal)
   const displayBalance = rawEarningsBalance.toLocaleString()
 
   return (

--- a/src/views/Farms/components/FarmCard/StakeAction.tsx
+++ b/src/views/Farms/components/FarmCard/StakeAction.tsx
@@ -15,6 +15,7 @@ interface FarmCardActionsProps {
   tokenName?: string
   pid?: number
   depositFeeBP?: number
+  decimal?: number
 }
 
 const IconButtonWrapper = styled.div`
@@ -24,17 +25,17 @@ const IconButtonWrapper = styled.div`
   }
 `
 
-const StakeAction: React.FC<FarmCardActionsProps> = ({ stakedBalance, tokenBalance, tokenName, pid, depositFeeBP}) => {
+const StakeAction: React.FC<FarmCardActionsProps> = ({ stakedBalance, tokenBalance, tokenName, pid, depositFeeBP, decimal}) => {
   const TranslateString = useI18n()
-  const { onStake } = useStake(pid)
-  const { onUnstake } = useUnstake(pid)
+  const { onStake } = useStake(pid, decimal)
+  const { onUnstake } = useUnstake(pid, decimal)
 
-  const rawStakedBalance = getBalanceNumber(stakedBalance)
+  const rawStakedBalance = getBalanceNumber(stakedBalance, decimal)
   const displayBalance = rawStakedBalance.toLocaleString()
 
-  const [onPresentDeposit] = useModal(<DepositModal max={tokenBalance} onConfirm={onStake} tokenName={tokenName} depositFeeBP={depositFeeBP} />)
+  const [onPresentDeposit] = useModal(<DepositModal max={tokenBalance} onConfirm={onStake} tokenName={tokenName} depositFeeBP={depositFeeBP}  />)
   const [onPresentWithdraw] = useModal(
-    <WithdrawModal max={stakedBalance} onConfirm={onUnstake} tokenName={tokenName} />,
+    <WithdrawModal max={stakedBalance} onConfirm={onUnstake} tokenName={tokenName} decimal={decimal} />,
   )
 
   const renderStakingButtons = () => {

--- a/src/views/Farms/components/WithdrawModal.tsx
+++ b/src/views/Farms/components/WithdrawModal.tsx
@@ -8,12 +8,13 @@ import { getFullDisplayBalance } from 'utils/formatBalance'
 
 interface WithdrawModalProps {
   max: BigNumber
-  onConfirm: (amount: string) => void
+  onConfirm: (amount: string, decimal: number) => void
   onDismiss?: () => void
   tokenName?: string
+  decimal?: number
 }
 
-const WithdrawModal: React.FC<WithdrawModalProps> = ({ onConfirm, onDismiss, max, tokenName = '' }) => {
+const WithdrawModal: React.FC<WithdrawModalProps> = ({ onConfirm, onDismiss, max, tokenName = '', decimal }) => {
   const [val, setVal] = useState('')
   const [pendingTx, setPendingTx] = useState(false)
   const TranslateString = useI18n()
@@ -49,7 +50,7 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({ onConfirm, onDismiss, max
           disabled={pendingTx}
           onClick={async () => {
             setPendingTx(true)
-            await onConfirm(val)
+            await onConfirm(val, decimal)
             setPendingTx(false)
             onDismiss()
           }}

--- a/src/views/Pools/components/CompoundModal.tsx
+++ b/src/views/Pools/components/CompoundModal.tsx
@@ -9,12 +9,13 @@ import { getFullDisplayBalance } from 'utils/formatBalance'
 
 interface DepositModalProps {
   earnings: BigNumber
-  onConfirm: (amount: string) => void
+  onConfirm: (amount: string, decimal: number) => void
   onDismiss?: () => void
   tokenName?: string
+  decimal?: number
 }
 
-const CompoundModal: React.FC<DepositModalProps> = ({ earnings, onConfirm, onDismiss, tokenName = '' }) => {
+const CompoundModal: React.FC<DepositModalProps> = ({ earnings, onConfirm, onDismiss, tokenName = '', decimal }) => {
   const [pendingTx, setPendingTx] = useState(false)
   const TranslateString = useI18n()
   const fullBalance = useMemo(() => {
@@ -39,7 +40,7 @@ const CompoundModal: React.FC<DepositModalProps> = ({ earnings, onConfirm, onDis
           disabled={pendingTx}
           onClick={async () => {
             setPendingTx(true)
-            await onConfirm(fullBalance)
+            await onConfirm(fullBalance, decimal)
             setPendingTx(false)
             onDismiss()
           }}

--- a/src/views/Pools/components/DepositModal.tsx
+++ b/src/views/Pools/components/DepositModal.tsx
@@ -8,12 +8,13 @@ import { getFullDisplayBalance } from '../../../utils/formatBalance'
 
 interface DepositModalProps {
   max: BigNumber
-  onConfirm: (amount: string) => void
+  onConfirm: (amount: string, decimal: number) => void
   onDismiss?: () => void
   tokenName?: string
+  decimal?: number
 }
 
-const DepositModal: React.FC<DepositModalProps> = ({ max, onConfirm, onDismiss, tokenName = '' }) => {
+const DepositModal: React.FC<DepositModalProps> = ({ max, onConfirm, onDismiss, tokenName = '', decimal = 18 }) => {
   const [val, setVal] = useState('')
   const [pendingTx, setPendingTx] = useState(false)
   const TranslateString = useI18n()
@@ -50,7 +51,7 @@ const DepositModal: React.FC<DepositModalProps> = ({ max, onConfirm, onDismiss, 
           disabled={pendingTx}
           onClick={async () => {
             setPendingTx(true)
-            await onConfirm(val)
+            await onConfirm(val, decimal)
             setPendingTx(false)
             onDismiss()
           }}

--- a/src/views/Pools/components/PoolCard.tsx
+++ b/src/views/Pools/components/PoolCard.tsx
@@ -163,7 +163,7 @@ const PoolCard: React.FC<HarvestProps> = ({ pool }) => {
                     isOldSyrup
                       ? async () => {
                           setPendingTx(true)
-                          await onUnstake('0')
+                          await onUnstake('0', 18)
                           setPendingTx(false)
                         }
                       : onPresentWithdraw

--- a/src/views/Pools/components/WithdrawModal.tsx
+++ b/src/views/Pools/components/WithdrawModal.tsx
@@ -8,12 +8,13 @@ import { getFullDisplayBalance } from '../../../utils/formatBalance'
 
 interface WithdrawModalProps {
   max: BigNumber
-  onConfirm: (amount: string) => void
+  onConfirm: (amount: string, decimal: number) => void
   onDismiss?: () => void
   tokenName?: string
+  decimal?: number
 }
 
-const WithdrawModal: React.FC<WithdrawModalProps> = ({ onConfirm, onDismiss, max, tokenName = '' }) => {
+const WithdrawModal: React.FC<WithdrawModalProps> = ({ onConfirm, onDismiss, max, tokenName = '', decimal=18 }) => {
   const [val, setVal] = useState('')
   const [pendingTx, setPendingTx] = useState(false)
   const TranslateString = useI18n()
@@ -49,7 +50,7 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({ onConfirm, onDismiss, max
           disabled={pendingTx}
           onClick={async () => {
             setPendingTx(true)
-            await onConfirm(val)
+            await onConfirm(val, decimal)
             setPendingTx(false)
             onDismiss()
           }}


### PR DESCRIPTION
I added the type: decimal and now every time the _**getBalanceNumber**_ function is called it will take into account the decimal places of the token, this solves your problem.